### PR TITLE
[OnePasswordSDKProvider]Enable specifying the vault by UUID

### DIFF
--- a/apis/externalsecrets/v1/secretstore_onepassword_sdk_types.go
+++ b/apis/externalsecrets/v1/secretstore_onepassword_sdk_types.go
@@ -36,7 +36,7 @@ type IntegrationInfo struct {
 
 // OnePasswordSDKProvider configures a store to sync secrets using the 1Password sdk.
 type OnePasswordSDKProvider struct {
-	// Vault defines the vault's name to access. Do NOT add op:// prefix. This will be done automatically.
+	// Vault defines the vault's name or uuid to access. Do NOT add op:// prefix. This will be done automatically.
 	Vault string `json:"vault"`
 	// IntegrationInfo specifies the name and version of the integration built using the 1Password Go SDK.
 	// If you don't know which name and version to use, use `DefaultIntegrationName` and `DefaultIntegrationVersion`, respectively.

--- a/pkg/provider/onepasswordsdk/client.go
+++ b/pkg/provider/onepasswordsdk/client.go
@@ -324,21 +324,21 @@ func (p *Provider) PushSecret(ctx context.Context, secret *corev1.Secret, ref es
 	return nil
 }
 
-func (p *Provider) GetVault(ctx context.Context, name string) (string, error) {
+func (p *Provider) GetVault(ctx context.Context, titleOrUuid string) (string, error) {
 	vaults, err := p.client.VaultsAPI.List(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to list vaults: %w", err)
 	}
 
 	for _, v := range vaults {
-		if v.Title == name {
+		if v.Title == titleOrUuid || v.ID == titleOrUuid {
 			// cache the ID so we don't have to repeat this lookup.
 			p.vaultID = v.ID
 			return v.ID, nil
 		}
 	}
 
-	return "", fmt.Errorf("vault %s not found", name)
+	return "", fmt.Errorf("vault %s not found", titleOrUuid)
 }
 
 func (p *Provider) findItem(ctx context.Context, name string) (onepassword.Item, error) {

--- a/pkg/provider/onepasswordsdk/client_test.go
+++ b/pkg/provider/onepasswordsdk/client_test.go
@@ -592,6 +592,31 @@ func TestDeleteItemField(t *testing.T) {
 	}
 }
 
+func TestGetVault(t *testing.T) {
+	fc := &fakeClient{
+		listAllResult: []onepassword.VaultOverview{
+			{
+				ID:    "vault-id",
+				Title: "vault-title",
+			},
+		},
+	}
+
+	p := &Provider{
+		client: &onepassword.Client{
+			VaultsAPI: fc,
+		},
+	}
+
+	titleOrUuids := []string{"vault-title", "vault-id"}
+
+	for _, titleOrUuid := range titleOrUuids {
+		vaultID, err := p.GetVault(context.Background(), titleOrUuid)
+		require.NoError(t, err)
+		require.Equal(t, fc.listAllResult[0].ID, vaultID)
+	}
+}
+
 type fakeLister struct {
 	listAllResult []onepassword.ItemOverview
 	createCalled  bool


### PR DESCRIPTION
- Modified the Vault field comment to clarify it can accept either the vault's name or uuid.
- Updated the GetVault method to use titleOrUuid for better clarity and functionality, allowing it to match both title and ID.

## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
